### PR TITLE
fixed travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,13 @@ addons:
   apt:
     packages:
       - g++-5
-      - qtbase5-dev
-      - qtmultimedia5-dev
-    sources: &sources
-      - llvm-toolchain-precise-3.8
+      - qt510base
+      - qt510multimedia
+    sources:
       - ubuntu-toolchain-r-test
+      - sourceline: 'ppa:beineri/opt-qt-5.10.1-trusty'
 
 script:
-  - cmake .
+  - /opt/qt510/bin/qt510-env.sh
+  - cmake . -DQt5_DIR=$QTDIR/lib/cmake/Qt5
   - make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt5Multimedia)
-find_package(Qt5Widgets)
+find_package(Qt5 COMPONENTS Widgets Multimedia)
 
 set(output_dir bin)
 


### PR DESCRIPTION
use a custom ppa to install qt - the qt version provided by qtbase5-dev etc is only 5.2, but we need at least 5.3 for camera support